### PR TITLE
Permission based KeepInventory

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-plugin_version=1.4.3
+plugin_version=1.5

--- a/src/main/java/io/github/niestrat99/keepinvindividual/configuration/Messages.java
+++ b/src/main/java/io/github/niestrat99/keepinvindividual/configuration/Messages.java
@@ -21,6 +21,9 @@ public class Messages {
         messages.addDefault("info.disabled", "&7Successfully disabled KeepInventory for &e{player}&7!");
         messages.addDefault("info.reload.process", "&7Reloading configurations...");
         messages.addDefault("info.reload.success", "&7Configurations were successfully reloaded!");
+        messages.addDefault("info.on-join.enabled", "&7KeepInventory has been enabled for you by default!");
+        messages.addDefault("info.on-join.disabled", "&7KeepInventory has been disabled for you by default!");
+        messages.addDefault("info.on-join.blacklisted", "&7KeepInventory disabled, because you're in a blacklisted world!");
 
         messages.addDefault("error.no-permission", "&cYou do not have permission to use this command!");
         messages.addDefault("error.no-such-player", "&cPlayer &e{player} &cdoes not exist.");

--- a/src/main/java/io/github/niestrat99/keepinvindividual/listeners/PlayerListener.java
+++ b/src/main/java/io/github/niestrat99/keepinvindividual/listeners/PlayerListener.java
@@ -46,6 +46,7 @@ public class PlayerListener implements Listener {
                 if (Config.config.getBoolean("debug.send-on-join-notification")) {
                     player.sendMessage(KeepInvIndividual.plTitle + ChatColor.translateAlternateColorCodes('&', Objects.requireNonNull(Messages.messages.getString("info.on-join.blacklisted"))));
                 }
+                return;
             }
             if (!playerIsInList(player)) {
                 if (KeepInvIndividual.mySqlEnabled) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,6 +27,12 @@ permissions:
   ki.keepxp:
     default: op
 
+  ki.onjoin.on:
+    default: op
+
+  ki.onjoin.off:
+    default: op
+
 commands:
   keepinventory:
     description: Used to enable/disable keepInventory for players, reload config files or check a list.


### PR DESCRIPTION
Practically adds the permission nodes `ki.onjoin.on` and `ki.onjoin.off` that allow players to either have KeepInventory enabled or disabled on default, as soon as they join the server.

World blacklist will not be bypassed.
If a player joins with `ki.onjoin.on`, but is in a blacklisted world then it won't have KeepInventory enabled.

Additionally, the player can also be notified about that once they join, if the config option `debug.send-on-join-notification` is set to `true`.

As always, the messages sent to the player are also fully customizable inside messages.yml.